### PR TITLE
Hiera and pip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,34 @@ Usage:
 ------
 
 You an install the module by just defining a logfile you'd like to ship if the
-beaver defaults work for you or if you are using puppet >= 3.0 with hiera:
+beaver defaults work for you.
+### Example configuration with manifests
 <pre>
   beaver::stanza { '/var/log/messages':
     type    => 'syslog',
     tags    => ['messages', 'prod'],
   }
 </pre>
+
+### Example configuration with hiera
+Here it is assumed that the classes are loaded from hiera automatically [(more info on puppetlabs)](https://docs.puppetlabs.com/hiera/1/puppet.html#assigning-classes-to-nodes-with-hiera-hierainclude).
+```
+---
+classes:
+  - beaver
+  - beaver::stanzas
+
+beaver::stanzas:
+  /var/log/messages:
+     type: 'tomcat'
+     tags:
+      - 'messages'
+      - 'prod'
+
+beaver::redis_host: 'redis-host.domain'
+beaver::redis_namespace: 'logstash'
+beaver::logstash_version: '1'
+```
 
 If beaver configuration is required, just specify it in the class:
 <pre>

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -35,12 +35,12 @@ class beaver::package (
 
   if $provider == 'virtualenv' {
     python::virtualenv { $venv:
-      ensure  => present,
-      version => $python_version,
-      owner   => $user,
-      group   => $group,
+	    ensure  => present,
+	    version => $python_version,
+	    owner   => $user,
+	    group   => $group,
       require => Class['python'],
-    }
+    } 
 
     python::pip { $package_name:
       ensure       => present,
@@ -52,6 +52,22 @@ class beaver::package (
       notify       => Class['beaver::service'],
     }
 
+    user { $user:
+      ensure     => present,
+      home       => $home,
+      managehome => true,
+      system     => true,
+    }
+  } elsif $provider == 'pip'{
+    python::pip { $package_name:
+      ensure       => present,
+      pkgname      => $package_name,
+      virtualenv   => 'system',
+      owner        => 'root',
+      require      => User[$user],
+      notify       => Class['beaver::service'],
+    }
+    
     user { $user:
       ensure     => present,
       home       => $home,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -35,10 +35,10 @@ class beaver::package (
 
   if $provider == 'virtualenv' {
     python::virtualenv { $venv:
-	    ensure  => present,
-	    version => $python_version,
-	    owner   => $user,
-	    group   => $group,
+      ensure  => present,
+      version => $python_version,
+      owner   => $user,
+      group   => $group,
       require => Class['python'],
     } 
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -40,7 +40,7 @@ class beaver::package (
       owner   => $user,
       group   => $group,
       require => Class['python'],
-    } 
+    }
 
     python::pip { $package_name:
       ensure       => present,
@@ -58,14 +58,14 @@ class beaver::package (
       managehome => true,
       system     => true,
     }
-  } elsif $provider == 'pip'{
+  } elsif $provider == 'pip' {
     python::pip { $package_name:
-      ensure       => present,
-      pkgname      => $package_name,
-      virtualenv   => 'system',
-      owner        => 'root',
-      require      => User[$user],
-      notify       => Class['beaver::service'],
+      ensure     => present,
+      pkgname    => $package_name,
+      virtualenv => 'system',
+      owner      => 'root',
+      require    => User[$user],
+      notify     => Class['beaver::service'],
     }
     
     user { $user:

--- a/manifests/stanzas.pp
+++ b/manifests/stanzas.pp
@@ -1,0 +1,20 @@
+# == Class: beaver::stanzas
+#
+# This class can be included to load stanzas from hiera
+#
+#
+# === Authors
+#
+# * pvbouwel <https://github.com/pvbouwel>
+#
+#
+# === Copyright
+#
+# Copyright 2013 EvenUp.
+#
+class beaver::stanzas {
+  $hiera_config = hiera_hash('beaver::stanzas', undef)
+  if $hiera_config {
+    create_resources(stanza, $hiera_config)
+  }
+}


### PR DESCRIPTION
When using pip to provide the beaver package but without a virtual environment your puppet run can fail from time to time, depending on the OS package you use to install pip.  The puppet package pip provider doesn't play nice with all pip builds where the python module of stankevich works every time.