### PR TITLE
Install pip/virtualenv if needed + Create systemd unit file

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -33,7 +33,21 @@ class beaver::package (
     "VIRTUAL_ENV=${venv}",
   ]
 
+  if $provider == 'pip' {
+    class { 'python':
+      pip             => 'present',
+      manage_gunicorn => false
+    }
+  }
+
   if $provider == 'virtualenv' {
+    # Installs python pip/virtualenv.
+    class { 'python':
+      pip             => 'present',
+      virtualenv      => 'present',
+      manage_gunicorn => false
+    }
+
     python::virtualenv { $venv:
       ensure  => present,
       version => $python_version,
@@ -62,6 +76,7 @@ class beaver::package (
     package { $package_name:
       ensure   => $version,
       provider => $provider,
+      require  => Class['python'],
       notify   => Class['beaver::service'],
     }
   }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -35,7 +35,7 @@ class beaver::package (
 
   if $provider == 'pip' {
     class { 'python':
-      pip             => 'present',
+      pip             => true,
       manage_gunicorn => false
     }
   }
@@ -43,8 +43,8 @@ class beaver::package (
   if $provider == 'virtualenv' {
     # Installs python pip/virtualenv.
     class { 'python':
-      pip             => 'present',
-      virtualenv      => 'present',
+      pip             => true,
+      virtualenv      => true,
       manage_gunicorn => false
     }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -66,6 +66,13 @@ class beaver::package (
     }
   }
 
+  file { '/lib/systemd/system/beaver.service':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    content => template('beaver/beaver.service.erb'),
+  }
+
   file { '/etc/init.d/beaver':
     ensure  => file,
     mode    => '0555',

--- a/templates/beaver.service.erb
+++ b/templates/beaver.service.erb
@@ -2,7 +2,7 @@
 Description=Beaver log muncher for logstash
 
 [Service]
-User=beaver
+#User=beaver
 ExecStart=/usr/local/bin/beaver -c /etc/beaver.conf -t redis $BEAVER_OPTIONS
 Restart=on-failure
 KillMode=process

--- a/templates/beaver.service.erb
+++ b/templates/beaver.service.erb
@@ -3,6 +3,6 @@ Description=Beaver log muncher for logstash
 
 [Service]
 User=beaver
-ExecStart=/usr/local/bin/beaver -c ${BEAVER_CONFIG:-/etc/beaver.conf} -t redis $BEAVER_OPTIONS
+ExecStart=/usr/local/bin/beaver -c /etc/beaver.conf -t redis $BEAVER_OPTIONS
 Restart=on-failure
 KillMode=process

--- a/templates/beaver.service.erb
+++ b/templates/beaver.service.erb
@@ -2,6 +2,7 @@
 Description=Beaver log muncher for logstash
 
 [Service]
+User=beaver
 ExecStart=/usr/local/bin/beaver -c ${BEAVER_CONFIG:-/etc/beaver.conf} -t redis $BEAVER_OPTIONS
 Restart=on-failure
 KillMode=process

--- a/templates/beaver.service.erb
+++ b/templates/beaver.service.erb
@@ -1,0 +1,7 @@
+[Unit]
+Description=Beaver log muncher for logstash
+
+[Service]
+ExecStart=/usr/local/bin/beaver -c ${BEAVER_CONFIG:-/etc/beaver.conf} -t redis $BEAVER_OPTIONS
+Restart=on-failure
+KillMode=process


### PR DESCRIPTION
As I mentioned, I'm a complete novice at puppet. So I might be doing obviously stupid things.

One idea I have is to be able to set the install prefix for beaver on the system. The current init-script simply refers to `beaver` on its command line. However **systemd** requires absolute paths and gives this error:

```
[/lib/systemd/system/beaver.service:5] Executable path is not absolute, ignoring: beaver -c ${BEAVER_...R_OPTIONS
```

So I solved this by specifying the full path `/usr/local/bin/beaver`... Which I guess won't hold for all systems. I read in the puppet documentation that [`install_options`](https://docs.puppetlabs.com/references/latest/type.html#package-attribute-install_options) supports `INSTALLDIR` for all package types, so I guess that could  be used to place the executable in a known location.

I have no idea where to begin to add support for using `virtualenv` with systemd, so I didn't try. Someone else must contribute with that magic :)

This solves #43