### PR TITLE
allow stanza ensure absent

### DIFF
--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -4,6 +4,10 @@
 #
 #
 # === Parameters
+# [*ensure*]
+#   String.  Passed to file resource
+#   Default: file
+#
 # [*type*]
 #   String.  Type to be passed on to logstash
 #
@@ -49,6 +53,7 @@
 #
 define beaver::stanza (
   $type,
+  $ensure                 = 'file',
   $source                 = undef,
   $tags                   = [],
   $redis_url              = undef,
@@ -77,7 +82,7 @@ define beaver::stanza (
 
   $filename = regsubst($name, '[/:\n\*]', '_', 'GM')
   file { "/etc/beaver/conf.d/${filename}":
-    ensure  => 'file',
+    ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
     content => template("${module_name}/beaver.stanza.erb"),

--- a/spec/defines/beaver_stanza_spec.rb
+++ b/spec/defines/beaver_stanza_spec.rb
@@ -61,4 +61,21 @@ describe 'beaver::stanza', :type => :define do
     it { should contain_file('/etc/beaver/conf.d/_var_log_messages__.log') }
   end
 
+  context 'ensure file' do
+    let(:title) {'/var/log/messages:*.log'}
+    let(:params) { {
+      :type => 'json'
+    } }
+    it { should contain_file('/etc/beaver/conf.d/_var_log_messages__.log').with(:ensure => 'file') }
+  end
+
+  context 'ensure absent' do
+    let(:title) {'/var/log/messages:*.log'}
+    let(:params) { {
+      :type => 'json',
+      :ensure => 'absent'
+    } }
+    it { should contain_file('/etc/beaver/conf.d/_var_log_messages__.log').with(:ensure => 'absent') }
+  end
+
 end


### PR DESCRIPTION
We are starting a migration to filebeat and plan to do the migration in steps/phases. Currently the stanza does not support an ensure => absent - this patch adds it in.

The default behavior is un-changed so this should be safe. Also added test cases for ensure to be a file and absent - not sure if there are other ensure cases but I'm happy to add / tweak.